### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,55 @@
+name: Release 
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build-archlinux:
+    name: Build
+    runs-on: ubuntu-latest
+
+    outputs:
+      package-name: ${{ steps.build.outputs.package-name }}
+        
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7, '3.8', '3.9', '3.10', '3.11']
+
+    container:
+      image: 'archlinux:base'
+
+    steps:
+      - name: Prepare container
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm python-trio
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build distribution
+        run: python setup.py sdist bdist_wheel
+
+      - name: Package and Upload
+        run: |
+            export TAG=`git describe --tags`
+            export DISTDIR=netlink-bin-x86_64-${TAG:1}
+            echo "package-name=$DISTDIR.tar.gz" >> $GITHUB_OUTPUT
+            mkdir -p $DISTDIR/usr/share/licenses/netlink/
+            cp LICENSE $DISTDIR/usr/share/licenses/netlink/LICENSE
+            ls $DISTDIR | xargs tar -czf $DISTDIR.tar.gz -C $DISTDIR/
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+            files: ${{ steps.build.outputs.package-name }}
+            draft: true
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,8 +34,11 @@ jobs:
         run: python setup.py sdist
 
       - name: Package and Upload
+        id: tag-archive
         run: |
-            export TAG=`git tag`
+            git fetch --all --tags
+            export TAG=$(git tag)
+            echo "tag=$TAG" >> $GITHUB_ENV
             export PKGNAME=netlink-bin-x86_64-${TAG:1}
             echo "package-name=$PKGNAME.tar.gz" >> $GITHUB_OUTPUT
             ls | xargs tar -czf $PKGNAME.tar.gz
@@ -43,7 +46,10 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v1
         with:
-            files: ${{ steps.build.outputs.package-name }}
+            files: ${{ steps.tag-archive.outputs.package-name }}
+            prerelease: false
             draft: false
+            name: "netlink"
+            tag_name: ${{ env.tag }}
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,9 @@ jobs:
           pacman -Syu --noconfirm
           pacman -S --noconfirm python-trio git
 
+      - name: Git Safe Directory
+        run: 	git config --global --add safe.directory /__w/netlink/netlink
+        
       - name: Install Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build distribution
-        run: python setup.py sdist bdist_wheel
+        run: python setup.py sdist
 
       - name: Package and Upload
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Git Safe Directory
         run: 	git config --global --add safe.directory /__w/netlink/netlink
-        
+
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -44,6 +44,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
             files: ${{ steps.build.outputs.package-name }}
-            draft: true
+            draft: false
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Prepare container and Install Dependencies
         run: |
           pacman -Syu --noconfirm
-          pacman -S --noconfirm python-trio
+          pacman -S --noconfirm python-trio git
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,8 +1,6 @@
 name: Release 
 
-on:
-  push:
-    branches: master
+on: [push]
 
 jobs:
   build-archlinux:
@@ -12,16 +10,11 @@ jobs:
     outputs:
       package-name: ${{ steps.build.outputs.package-name }}
         
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.7, '3.8', '3.9', '3.10', '3.11']
-
     container:
       image: 'archlinux:base'
 
     steps:
-      - name: Prepare container
+      - name: Prepare container and Install Dependencies
         run: |
           pacman -Syu --noconfirm
           pacman -S --noconfirm python-trio
@@ -29,7 +22,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.x'
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,12 +32,10 @@ jobs:
 
       - name: Package and Upload
         run: |
-            export TAG=`git describe --tags`
-            export DISTDIR=netlink-bin-x86_64-${TAG:1}
-            echo "package-name=$DISTDIR.tar.gz" >> $GITHUB_OUTPUT
-            mkdir -p $DISTDIR/usr/share/licenses/netlink/
-            cp LICENSE $DISTDIR/usr/share/licenses/netlink/LICENSE
-            ls $DISTDIR | xargs tar -czf $DISTDIR.tar.gz -C $DISTDIR/
+            export TAG=`git tag`
+            export PKGNAME=netlink-bin-x86_64-${TAG:1}
+            echo "package-name=$PKGNAME.tar.gz" >> $GITHUB_OUTPUT
+            ls | xargs tar -czf $PKGNAME.tar.gz
 
       - name: Upload to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Fixes a number of issues with the "release" action:

- Git tags were not being fetched; the $TAG variable wasn't being set
- Add a Git "safe-directory" to fix dubious ownership error
- Install git utility
- No "bdist_wheel" for setup.py
- Python 3.12 does not have "setuptools"
- Tag the archive correctly